### PR TITLE
Resolve overlap on small screens

### DIFF
--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -90,6 +90,18 @@ body{
     width: 33.33%;
 }
 
+@media screen and (max-width: 1800px) {
+  .experienceCol {
+      width: 50%;
+  }
+}
+
+@media screen and (max-width: 800px) {
+  .experienceCol {
+      width: 100%;
+  }
+}
+
 .summary{
     visibility: hidden;
 }


### PR DESCRIPTION
fixes #6 to prevent overlapping pictures on Experience page on smaller screens